### PR TITLE
feat(wheel-of-meeting): add CLOUD_RUN_SA_EMAIL GitHub Actions secret

### DIFF
--- a/wheel-of-meeting/github-secrets.tf
+++ b/wheel-of-meeting/github-secrets.tf
@@ -21,3 +21,9 @@ resource "github_actions_secret" "gcp_project_id" {
   secret_name     = "GCP_PROJECT_ID"
   plaintext_value = data.google_project.wheel_of_meeting.project_id
 }
+
+resource "github_actions_secret" "cloud_run_sa_email" {
+  repository      = local.repository_name
+  secret_name     = "CLOUD_RUN_SA_EMAIL"
+  plaintext_value = google_service_account.cloud_run_runtime.email
+}


### PR DESCRIPTION
## Summary

- Adds `CLOUD_RUN_SA_EMAIL` as a GitHub Actions secret on the `wheel-of-meeting` repo
- Value is sourced from `google_service_account.cloud_run_runtime.email` (the runtime SA created in PR #106)
- Required by the `plan.yml` and `apply.yml` workflows which pass it as `TF_VAR_cloud_run_sa_email`

## Test plan

- [ ] Merge and confirm `terraform apply` completes cleanly
- [ ] Verify `CLOUD_RUN_SA_EMAIL` appears in koenighotze/wheel-of-meeting → Settings → Secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)