### PR TITLE
fix: grant run.admin to wheel-of-meeting admin SA

### DIFF
--- a/wheel-of-meeting/service-accounts.tf
+++ b/wheel-of-meeting/service-accounts.tf
@@ -19,8 +19,10 @@ resource "google_service_account" "cloud_run_runtime" {
 resource "google_project_iam_member" "wheel_of_meeting_iam_member_project" {
   for_each = toset([
     "roles/logging.logWriter",
-    # run.developer (not run.admin): deploy/update services without managing IAM on them
-    "roles/run.developer",
+    # run.admin required: the wheel-of-meeting Terraform manages IAM on the Cloud Run
+    # service (google_cloud_run_v2_service_iam_member.invoker), which needs
+    # run.services.setIamPolicy — only granted by run.admin, not run.developer.
+    "roles/run.admin",
   ])
   project = data.google_project.wheel_of_meeting.project_id
   role    = each.value


### PR DESCRIPTION
## Summary

- The `wheel-of-meeting` Terraform manages IAM on the Cloud Run service via `google_cloud_run_v2_service_iam_member`, which requires `run.services.setIamPolicy`
- `roles/run.developer` does not include this permission, causing a 403 in the apply workflow
- Replaced `roles/run.developer` with `roles/run.admin` on the admin SA

Fixes: https://github.com/koenighotze/wheel-of-meeting/actions/runs/24337645394/job/71058428829

## Test plan
- [ ] Apply kh-gcp-seed Terraform to update the SA role binding in GCP
- [ ] Re-run the wheel-of-meeting apply workflow and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)