### PR TITLE
fix: grant secretmanager.secretAdmin to wheel-of-meeting admin SA

### DIFF
--- a/wheel-of-meeting/service-accounts.tf
+++ b/wheel-of-meeting/service-accounts.tf
@@ -23,6 +23,10 @@ resource "google_project_iam_member" "wheel_of_meeting_iam_member_project" {
     # service (google_cloud_run_v2_service_iam_member.invoker), which needs
     # run.services.setIamPolicy — only granted by run.admin, not run.developer.
     "roles/run.admin",
+    # secretmanager.secretAdmin required: the wheel-of-meeting Terraform creates and
+    # manages Secret Manager secrets (secrets.tf). secretAccessor alone is not enough —
+    # the admin SA needs secretmanager.secrets.create to provision the secret shells.
+    "roles/secretmanager.secretAdmin",
   ])
   project = data.google_project.wheel_of_meeting.project_id
   role    = each.value


### PR DESCRIPTION
## Summary
- `terraform apply` in wheel-of-meeting was failing with 403 on `secretmanager.secrets.create`
- The admin SA lacked any Secret Manager role — it could not create the secret shells defined in `infra/secrets.tf`
- Adding `roles/secretmanager.secretAdmin` at project level allows the SA to create and manage secrets

## Why secretAdmin and not a narrower role
`secretmanager.secretAdmin` grants create/delete/update on secrets but **not** `secretmanager.versions.access` (reading secret values). That accessor right remains with the runtime SA only, preserving least-privilege at runtime.

## Test plan
- [ ] Apply this via the kh-gcp-seed apply workflow
- [ ] Re-run the wheel-of-meeting apply workflow — `google_secret_manager_secret.partners` and `.leads` should be created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)