### PR TITLE
fix: correct Secret Manager role to roles/secretmanager.admin

### DIFF
--- a/wheel-of-meeting/service-accounts.tf
+++ b/wheel-of-meeting/service-accounts.tf
@@ -23,10 +23,10 @@ resource "google_project_iam_member" "wheel_of_meeting_iam_member_project" {
     # service (google_cloud_run_v2_service_iam_member.invoker), which needs
     # run.services.setIamPolicy — only granted by run.admin, not run.developer.
     "roles/run.admin",
-    # secretmanager.secretAdmin required: the wheel-of-meeting Terraform creates and
+    # secretmanager.admin required: the wheel-of-meeting Terraform creates and
     # manages Secret Manager secrets (secrets.tf). secretAccessor alone is not enough —
     # the admin SA needs secretmanager.secrets.create to provision the secret shells.
-    "roles/secretmanager.secretAdmin",
+    "roles/secretmanager.admin",
   ])
   project = data.google_project.wheel_of_meeting.project_id
   role    = each.value


### PR DESCRIPTION
## Summary
- PR #114 was merged with `roles/secretmanager.secretAdmin` which does not exist as a GCP predefined role
- The correct role is `roles/secretmanager.admin` (full Secret Manager admin access)
- This caused the kh-gcp-seed apply to fail with `Error 400: Role roles/secretmanager.secretAdmin is not supported for this resource`

## Test plan
- [ ] Apply via kh-gcp-seed apply workflow — IAM binding should be created successfully
- [ ] Re-run wheel-of-meeting apply — secrets should be created without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)