### PR TITLE
fix: grant Cloud Run Service Agent AR reader access for wheel-of-meeting

### DIFF
--- a/platform.tf
+++ b/platform.tf
@@ -7,6 +7,9 @@ module "platform" {
     module.wheel_of_meeting.admin_service_account.email,
     # Cloud Run runtime SA needs to pull images from the platform AR
     module.wheel_of_meeting.cloud_run_runtime_sa_email,
+    # Cloud Run Service Agent for wheel-of-meeting must be able to pull images
+    # from this cross-project registry during deployment
+    "service-${module.wheel_of_meeting.wheel_of_meeting_terraform_project_number}@serverless-robot-prod.iam.gserviceaccount.com",
   ]
   writer_service_accounts = [
     # Admin SA (used by GitHub Actions) pushes images directly via docker push


### PR DESCRIPTION
## Summary

- Grant the Cloud Run Service Agent for the \`wheel-of-meeting\` project \`roles/artifactregistry.reader\` on the platform Artifact Registry

## Problem

Deployments to Cloud Run were failing with:

\`\`\`
service-135369082683@serverless-robot-prod.iam.gserviceaccount.com must have
permission to read the image from project [platform-13bf3f03]
\`\`\`

GCP always uses the **Cloud Run Service Agent** (\`service-{PROJECT_NUMBER}@serverless-robot-prod.iam.gserviceaccount.com\`) to pull images during deployment — even when a custom runtime SA is specified. Since the image lives in the \`platform\` project and Cloud Run runs in \`wheel-of-meeting\`, the service agent needs cross-project AR read access.

## Fix

Add the Cloud Run Service Agent email (derived from the wheel-of-meeting project number, already exported by the module) to \`reader_service_accounts\` in \`platform.tf\`.

## Test plan

- [ ] Apply Terraform and verify no errors
- [ ] Trigger a deployment in wheel-of-meeting and confirm the \`Deploy to Cloud Run\` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)